### PR TITLE
Bug fix for infinite loop.

### DIFF
--- a/ngx_http_upstream_hash_module.c
+++ b/ngx_http_upstream_hash_module.c
@@ -323,7 +323,7 @@ ngx_http_upstream_free_hash_peer(ngx_peer_connection_t *pc, void *data,
             "upstream_hash: free upstream hash peer try %ui", pc->tries);
 
     if (state & (NGX_PEER_FAILED|NGX_PEER_NEXT)
-            && pc->tries) {
+            && (ngx_int_t) pc->tries > 0) {
         current = ngx_http_upstream_get_hash_peer_index(uhpd);
 
         uhpd->tried[ngx_bitvector_index(current)] |= ngx_bitvector_bit(current);


### PR DESCRIPTION
Consider the following step:

hash_again = 1  => pc->tries = 2

After ngx_http_upstream_init_hash_peer -> ngx_http_upstream_hash_next_peer, pc->tries becomes 1.
If the first upstream fails, after ngx_http_upstream_free_hash_peer -> ngx_http_upstream_hash_next_peer,
pc->tries becomes (ngx_uint_t) -1.

Maybe a better patch is needed, and this one just fix the problem.

Easy to reproduce: (curl localhost/xxxx)

``` nginx
upstream not_exists {
  server localhost:9999;
  server localhost:9999;
  server localhost:9999;
  server localhost:9999;
  server localhost:9999;
  server localhost:9999;
  server localhost:9999;
  server localhost:9999;

  hash $args;
  hash_again 1;
}

server {
  listen 80;

  location / {
    proxy_pass http://not_exists;
  }
}
```
